### PR TITLE
use the PrivateRoute for the /settings and /editor

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -61,10 +61,10 @@ const App = (props) => {
           <Route path="/register" component={Register}/>
           <PrivateRoute path="/editor/:slug" currentUser={props.currentUser} component={Editor} />
           <PrivateRoute path="/editor" currentUser={props.currentUser} component={Editor} />
-          <PrivateRoute path="/item/:id" currentUser={props.currentUser} component={Item} />
+          <Route path="/item/:id" currentUser={props.currentUser} component={Item} />
           <PrivateRoute path="/settings" currentUser={props.currentUser} component={Settings} />
-          <PrivateRoute path="/:username/favorites" currentUser={props.currentUser} component={ProfileFavorites} />
-          <PrivateRoute path="/:username" currentUser={props.currentUser} component={Profile} />
+          <Route path="/:username/favorites" currentUser={props.currentUser} component={ProfileFavorites} />
+          <Route path="/:username" currentUser={props.currentUser} component={Profile} />
         </Switch>
       </div>
     );


### PR DESCRIPTION
# Description

We now have a PrivateRoute component which we can use to prevent unauthenticated users from accessing restricted pages.
We use the PrivateRoute component for the /settings and /editor route so that only authenticated users can access it.