### PR TITLE
refactor with promise.all

### DIFF
--- a/frontend/src/components/Item/utils/ItemFetcher.js
+++ b/frontend/src/components/Item/utils/ItemFetcher.js
@@ -1,8 +1,11 @@
 import agent from "../../../agent";
 
 export async function getItemAndComments(id) {
-  const item = await agent.Items.get(id);
-  const comments = await agent.Comments.forItem(id);
+  const [item, comments] = await Promise.all([
+    agent.Items.get(id),
+    agent.Comments.forItem(id)
+  ]);
 
   return [item, comments];
 }
+


### PR DESCRIPTION
# Description

Parallelize API Requests: Currently, the code fetches the item and comments sequentially using await. To improve loading speed, you can fetch the item and comments in parallel using Promise.all. This allows both requests to be initiated simultaneously, potentially reducing the overall loading time.